### PR TITLE
Repurpose 'latest' to be current stable release.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -114,10 +114,10 @@ Double check your docker version:
 ./manage-ohb-docker.sh check-docker
 ```
 
-Do an install. Note that if you are running it from a git checkout, it will use the git tag or branch name. If you are running it standalone you should provide it the tag you want to install. It defaults to ```latest```:
+Do an install. Note that if you are running it from a git checkout, it will use the git tag or branch name. If you are running it standalone you should provide it the tag you want to install. It defaults to ```edge```:
 
 ```
-# put in the version you want or set to latest
+# put in the version you want or set to 'edge'
 ./manage-ohb-docker.sh install -t <insert version here>
 ```
 
@@ -144,7 +144,7 @@ Go to the project readme and look for information about the '-b' otion to hamclo
 ## The steps if you want to create your own image
 You'll need a git checkout of the version you want to build. See above for getting a git clone and checkout.
 
-The build-image.sh utility will create an image for you based on the git branch you have checked out. If you aren't on a git tag, the resulting image will be tagged 'latest':
+The build-image.sh utility will create an image for you based on the git branch you have checked out. If you aren't on a git tag, the resulting image will be tagged 'edge':
 ```
 ./build-image.sh
 ```
@@ -169,7 +169,7 @@ If it shows the latest version at the end, then use it to upgrade OHB:
 ```
 
 ## versions v0.23 and older
-Get the latest manager utility and run the manager utility with 'upgrade' command. Like install, it defaults to the current version, or falls back to latest. If the default version isn't what you want, provide the -t option.
+Get the latest manager utility and run the manager utility with 'upgrade' command. Like install, it defaults to the current version, or falls back to 'edge'. If the default version isn't what you want, provide the -t option.
 ```
 # Get the version you want. Let's assume it's version: <version>
 curl -sL -o manage-ohb-docker.sh https://github.com/openhamclock/open-hamclock-backend/releases/download/<version>/manage-ohb-docker-<version>.sh

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -23,8 +23,8 @@ HTTP_PORT=80
 
 # Don't set anything past here
 if ! TAG=$(git describe --exact-match --tags 2>/dev/null); then
-    echo "NOTE: Not currently on a tag. Using 'latest'."
-    TAG=latest
+    echo "NOTE: Not currently on a tag. Using 'edge'."
+    TAG=edge
     GIT_VERSION=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 else
     GIT_VERSION=$TAG
@@ -44,7 +44,7 @@ $THIS:
 
     Builds the latest docker image based on the current git branch. It will figure out
     if on a git tag and will use that for the docker image tag. Otherwise falls back
-    to 'latest'.
+    to 'edge'.
 
     -m: multi-platform image buld for: linux/amd64 linux/arm64 linux/arm/v7
         - argument is ignored when run with -c
@@ -106,7 +106,7 @@ do_all() {
 }
 
 warn_image_tag() {
-    if [ $TAG != latest ]; then
+    if [ $TAG != edge ]; then
         if [ $MULTI_PLATFORM == true ]; then
             docker manifest inspect $IMAGE >/dev/null
             if [ $? -eq 0 ]; then
@@ -160,11 +160,16 @@ build_image() {
     echo "Building image for '$IMAGE_BASE:$TAG'"
     pushd "$HERE/.." >/dev/null
     if [ $MULTI_PLATFORM == true ]; then
+        # only use latest on stable versions
+        if [[ $TAG =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+            TAG_LATEST="-t $IMAGE_BASE:latest"
+        fi
         docker buildx build \
             $NOCACHE_ARG \
             --pull \
             --build-arg GIT_VERSION=${GIT_VERSION} \
             -t $IMAGE \
+            $TAG_LATEST \
             -f docker/Dockerfile \
             --platform linux/amd64,linux/arm64 \
             --push \

--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # at release time, this value is set to the tagged release
-OHB_MANAGER_VERSION=latest
+OHB_MANAGER_VERSION=edge
 # tags to use
 DEFAULT_VOACAP_SERVICE_TAG=1.19
 DEFAULT_PSKR_MQTT_CACHE_TAG=1.19
@@ -1080,7 +1080,7 @@ determine_tag() {
         return
     fi
 
-    # upgrade shouldn't use the current tag unless it's 'latest'. 
+    # upgrade shouldn't use the current tag unless it's 'edge'. 
     # GIT_TAG would be empty and we'll get DEFAULT_TAG
 
     # second precedence


### PR DESCRIPTION
We did this based on a user request for hamclock. For consistency let's do it for ohb also. latest becomes an alias for the latest stable release. 'edge' is used for latest untagged builds