### PR TITLE
Fix permissions issues and tmp folder moves

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,7 @@ RUN cd /opt/hamclock-backend && \
 
 # Install hamclock-backend
 COPY --exclude=**/__pycache__/ --exclude=**/__init__.py --from=build-support /usr/local/lib/python3.13/dist-packages/ /usr/local/lib/python3.13/dist-packages/
-COPY --from=build-support /opt/pipx/sondehub/ /opt/pipx/sondehub/
+COPY --exclude=**/__pycache__/ --from=build-support /opt/pipx/sondehub/ /opt/pipx/sondehub/
 COPY --exclude=docker/ohb-maps.tar.zst . /opt/hamclock-backend/
 RUN cd /opt/hamclock-backend && \
     mv  docker/run.sh /opt && \
@@ -87,7 +87,7 @@ RUN cd /opt/hamclock-backend && \
     awk '/^[0-9\*]/ {full=$0; $1=$2=$3=$4=$5=""; sub(/^[ \t]+/, "", $0); exec=$0; sub(/[[:space:]]*[>|].*$/, "", exec); print "echo \"Running: " exec "\""; print $0; next} {print}' scripts/crontab | sed 's/[[:space:]]*2>&1//g' > prime_crontabs.sh && \
     # \
     # set permissions \
-    chown -R www-data:www-data . && \
+    chown -R www-data:www-data . /opt/pipx/sondehub && \
     chmod +x ham/HamClock/*.pl \
              scripts/* \
              prime_crontabs.sh \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -118,7 +118,7 @@ echo "Starting cron ..."
 echo "Starting blitzortung ..."
 (
     while true; do
-        /opt/hamclock-backend/scripts/blitzortung_daemon.py
+        /usr/sbin/runuser -u www-data -- /opt/hamclock-backend/scripts/blitzortung_daemon.py
         echo "$(date -u +%H:%M:%S): Blitzortung stopped. Restarting in 5 seconds ..."
         sleep 5
     done
@@ -127,7 +127,7 @@ echo "Starting blitzortung ..."
 echo "Starting HAB ..."
 (
     while true; do
-        /opt/pipx/sondehub/venvs/sondehub/bin/python3 /opt/hamclock-backend/scripts/hab_daemon.py
+        /usr/sbin/runuser -u www-data -- /opt/pipx/sondehub/venvs/sondehub/bin/python3 /opt/hamclock-backend/scripts/hab_daemon.py
         echo "$(date -u +%H:%M:%S): HAB stopped. Restarting in 5 seconds ..."
         sleep 5
     done

--- a/scripts/balloon_common.py
+++ b/scripts/balloon_common.py
@@ -94,15 +94,32 @@ def fmt_num(x, ndigits=None):
     return f"{x:.{ndigits}f}" if ndigits is not None else repr(x)
 
 
-def atomic_write_lines(path, lines):
-    """Write lines (no trailing newlines needed) to path, atomically (temp + rename)."""
+TMP_DIR = "/opt/hamclock-backend/htdocs/tmp"
+
+
+def write_lines(path, lines):
+    """Write lines directly to path (used for internal cache files) with 0644 permissions."""
     d = os.path.dirname(path) or "."
     os.makedirs(d, exist_ok=True)
+    with open(path, "w") as f:
+        for line in lines:
+            f.write(line + "\n")
+    os.chmod(path, 0o644)
+
+
+def atomic_write_lines(path, lines):
+    """Write lines atomically via htdocs/tmp (used for web-served balloons.txt)."""
+    d = TMP_DIR if os.path.isdir(TMP_DIR) else (os.path.dirname(path) or ".")
+    os.makedirs(d, exist_ok=True)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=d, prefix=".balloons.", suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as f:
             for line in lines:
                 f.write(line + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp, 0o644)
         os.replace(tmp, path)
     except Exception:
         try:
@@ -173,10 +190,11 @@ class BalloonState:
         return "|".join(f"{lat:.5f}:{lon:.5f}" for _, lat, lon in older)
 
     def save(self):
-        tmp = self.path + ".tmp"
-        with open(tmp, "w") as f:
+        d = os.path.dirname(self.path) or "."
+        os.makedirs(d, exist_ok=True)
+        with open(self.path, "w") as f:
             json.dump(self.data, f)
-        os.replace(tmp, self.path)
+        os.chmod(self.path, 0o644)
 
     def all_rows(self, type_tag):
         """build one balloons.txt-format CSV row per cached entry."""

--- a/scripts/fetch_pico.py
+++ b/scripts/fetch_pico.py
@@ -59,11 +59,11 @@ import os
 import time
 from datetime import datetime, timezone
 
-from balloon_common import BalloonState, http_get, clean_field, atomic_write_lines
+from balloon_common import BalloonState, http_get, clean_field, write_lines
 
 # ---- configuration -------------------------------------------------------
 PICO_CSV_URL         = "https://raw.githubusercontent.com/knormoyle/knormoyle.github.io/main/mymaps.csv"
-OUTDIR               = "/opt/hamclock-backend/htdocs/ham/HamClock/balloons"
+CACHEDIR             = "/opt/hamclock-backend/cache/balloons"
 DEFAULT_DROP_AGE_SEC = 4 * 86400   # mymaps.csv's own hysteresis is a couple days; give it margin
 # --------------------------------------------------------------------------
 
@@ -165,14 +165,17 @@ def fetch_and_update(state):
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                   formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--outdir", default=OUTDIR,
+    ap.add_argument("--cachedir", default=CACHEDIR,
                      help="directory to write pico.txt and the state cache into")
+    ap.add_argument("--outdir", default=None,
+                     help="deprecated alias for --cachedir")
     ap.add_argument("--drop-age", type=int, default=DEFAULT_DROP_AGE_SEC,
                      help="drop a cached flight if its last report is older than this, seconds")
     args = ap.parse_args()
 
-    os.makedirs(args.outdir, exist_ok=True)
-    state = BalloonState(os.path.join(args.outdir, "pico_state.json"), args.drop_age)
+    cachedir = args.outdir if args.outdir is not None else args.cachedir
+    os.makedirs(cachedir, exist_ok=True)
+    state = BalloonState(os.path.join(cachedir, "pico_state.json"), args.drop_age)
 
     try:
         fetch_and_update(state)
@@ -183,8 +186,8 @@ def main():
     state.save()
 
     rows = state.all_rows("PICO")
-    outpath = os.path.join(args.outdir, "pico.txt")
-    atomic_write_lines(outpath, rows)
+    outpath = os.path.join(cachedir, "pico.txt")
+    write_lines(outpath, rows)
     log.info(f"Wrote {len(rows)} flights -> {outpath}")
 
 

--- a/scripts/hab_daemon.py
+++ b/scripts/hab_daemon.py
@@ -47,10 +47,11 @@ from datetime import datetime
 
 import sondehub
 
-from balloon_common import BalloonState, http_get, clean_field, atomic_write_lines
+from balloon_common import BalloonState, http_get, clean_field, atomic_write_lines, write_lines
 
 # ---- configuration -------------------------------------------------------
 OUTDIR                       = "/opt/hamclock-backend/htdocs/ham/HamClock/balloons"   # adjust to your OHB webroot
+CACHEDIR                     = "/opt/hamclock-backend/cache/balloons"
 LOG_FILE                     = "/opt/hamclock-backend/logs/hab.log"
 HAB_URL_TMPL                 = "https://api.v2.sondehub.org/amateur?last={lookback}"
 HAB_TRACKER_URL              = "https://amateur.sondehub.org/"
@@ -129,14 +130,15 @@ def record_from_amateur_msg(rec):
 
 class HabDaemon:
 
-    def __init__(self, outdir, drop_age_sec, flush_interval_sec, stale_after_sec,
+    def __init__(self, outdir, cachedir, drop_age_sec, flush_interval_sec, stale_after_sec,
                  backfill_lookback_sec, silence_warn_sec=DEFAULT_SILENCE_WARN_SEC):
         self.outdir = outdir
+        self.cachedir = cachedir
         self.flush_interval_sec = flush_interval_sec
         self.stale_after_sec = stale_after_sec
         self.backfill_lookback_sec = backfill_lookback_sec
         self.silence_warn_sec = silence_warn_sec
-        self.state = BalloonState(os.path.join(outdir, "hab_state.json"), drop_age_sec)
+        self.state = BalloonState(os.path.join(cachedir, "hab_state.json"), drop_age_sec)
         self.lock = threading.Lock()
         self.last_msg_t = time.time()          # seed so the watchdog doesn't fire immediately
         self.n_msgs_total = 0                  # lifetime count, resets only on process restart
@@ -191,13 +193,13 @@ class HabDaemon:
             # between reading and clearing it
             msgs_this_interval = self.n_msgs_window
             self.n_msgs_window = 0
-        hab_path = os.path.join(self.outdir, "hab.txt")
-        atomic_write_lines(hab_path, hab_rows)
+        hab_path = os.path.join(self.cachedir, "hab.txt")
+        write_lines(hab_path, hab_rows)
 
         # also write the final merged balloons.txt HamClock actually fetches, folding
         # in whatever fetch_pico.py's cron has most recently written to pico.txt.
         pico_rows = []
-        pico_path = os.path.join(self.outdir, "pico.txt")
+        pico_path = os.path.join(self.cachedir, "pico.txt")
         try:
             with open(pico_path, "r") as f:
                 pico_rows = [line.rstrip("\n") for line in f if line.strip()]
@@ -273,6 +275,8 @@ class HabDaemon:
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--outdir", default=OUTDIR,
+                     help="directory to write balloons.txt into")
+    ap.add_argument("--cachedir", default=CACHEDIR,
                      help="directory to write hab.txt and the state cache into")
     ap.add_argument("--drop-age", type=int, default=DEFAULT_DROP_AGE_SEC,
                      help="drop a cached flight if its last report is older than this, seconds")
@@ -287,7 +291,8 @@ def main():
     args = ap.parse_args()
 
     os.makedirs(args.outdir, exist_ok=True)
-    daemon = HabDaemon(args.outdir, args.drop_age, args.flush_interval,
+    os.makedirs(args.cachedir, exist_ok=True)
+    daemon = HabDaemon(args.outdir, args.cachedir, args.drop_age, args.flush_interval,
                         args.stale_after, args.backfill_lookback, args.silence_warn)
     daemon.run()
 

--- a/scripts/merge_balloons.py
+++ b/scripts/merge_balloons.py
@@ -64,6 +64,7 @@ from balloon_common import atomic_write_lines
 # ---- configuration -------------------------------------------------------
 CREDIT_LINE    = "Credit: SondeHub + wsprlive"
 OUTDIR         = "/opt/hamclock-backend/htdocs/ham/HamClock/balloons"   # adjust to your OHB webroot
+CACHEDIR       = "/opt/hamclock-backend/cache/balloons"
 STALE_WARN_SEC = 30 * 60   # just a log hint, not enforced
 # --------------------------------------------------------------------------
 
@@ -90,15 +91,24 @@ def read_rows(path):
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                   formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--dir", default=OUTDIR,
-                     help="directory containing hab.txt/pico.txt, and where balloons.txt is written")
+    ap.add_argument("--outdir", default=OUTDIR,
+                     help="directory where balloons.txt is written")
+    ap.add_argument("--cachedir", default=CACHEDIR,
+                     help="directory containing hab.txt and pico.txt")
+    ap.add_argument("--dir", default=None, help=argparse.SUPPRESS)
     args = ap.parse_args()
 
-    hab_rows = read_rows(os.path.join(args.dir, "hab.txt"))
-    pico_rows = read_rows(os.path.join(args.dir, "pico.txt"))
+    outdir = args.dir if args.dir is not None else args.outdir
+    cachedir = args.dir if args.dir is not None else args.cachedir
+
+    os.makedirs(outdir, exist_ok=True)
+    os.makedirs(cachedir, exist_ok=True)
+
+    hab_rows = read_rows(os.path.join(cachedir, "hab.txt"))
+    pico_rows = read_rows(os.path.join(cachedir, "pico.txt"))
 
     lines = [CREDIT_LINE] + hab_rows + pico_rows
-    outpath = os.path.join(args.dir, "balloons.txt")
+    outpath = os.path.join(outdir, "balloons.txt")
     atomic_write_lines(outpath, lines)
     log.info(f"Wrote {len(hab_rows)} HAB + {len(pico_rows)} PICO -> {outpath}")
 

--- a/scripts/web15rss_fetch.py
+++ b/scripts/web15rss_fetch.py
@@ -82,6 +82,7 @@ def write_cache(name: str, lines: list[str], encoding: str | None = None) -> Non
             fh.flush()
             os.fsync(fh.fileno())
 
+        os.chmod(tmp_path, 0o644)
         os.replace(tmp_path, dest)  # atomic on Linux (same filesystem)
         log.info("[%s] Wrote %d lines to cache (%s)", name, len(lines), enc)
 


### PR DESCRIPTION
- we should run hab and blitzortung as user www-data
- ensure file permissions are consistent
- while not an issue, rss data should be 644 to be consistent
- some cache files shouldn't be in balloons/
- use a tmp file in htdocs to create balloons.txt
- in the image build, don't pull over __pycache__