### PR TITLE
Make the release workflow more robust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,22 @@ on:
         description: 'Tag name (e.g., v0.0.1)'
         required: true
         default: 'v0.0.0'
-      draft:
-        description: 'Create as a draft release'
-        required: false
-        type: boolean
-        default: false
+      publish_release:
+        description: 'Publish GitHub release directly (set to false for draft)'
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
       build_docker:
         description: 'Build and push Docker image'
-        required: false
-        type: boolean
-        default: true
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
 
 jobs:
   release:
@@ -37,7 +43,7 @@ jobs:
       - name: Create Release and Upload Assets
         env:
           GH_TOKEN: ${{ github.token }}
-          IS_DRAFT: ${{ inputs.draft }}
+          PUBLISH_RELEASE: ${{ inputs.publish_release }}
         run: |
           TAG="${{ inputs.tag_name || github.ref_name }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -70,7 +76,7 @@ jobs:
             cd dist && sha256sum * > CHECKSUMS && cd ..
 
             EXTRA_FLAGS=()
-            if [ "$IS_DRAFT" = "true" ]; then
+            if [ "$PUBLISH_RELEASE" = "false" ]; then
               EXTRA_FLAGS+=(--draft)
             fi
 
@@ -90,7 +96,7 @@ jobs:
     name: Build and Push Docker Image
     needs: release
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.release.result == 'success' || needs.release.result == 'skipped') && (github.event_name == 'push' || inputs.build_docker == true || inputs.build_docker == 'true') }}
+    if: ${{ needs.release.result == 'success' && (github.event_name == 'push' || inputs.build_docker == true || inputs.build_docker == 'true') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,17 +63,17 @@ gh auth status
 Trigger the release workflow manually using `workflow_dispatch`:
 
 ```bash
-# Trigger release build for version v2.0.16:
+# Trigger release build for version v2.0.16 (builds Docker and publishes release by default):
 gh workflow run release.yml -f tag_name=v2.0.16
 
 # Optional: create as a draft release:
-gh workflow run release.yml -f tag_name=v2.0.16 -f draft=true
+gh workflow run release.yml -f tag_name=v2.0.16 -f publish_release=false
 
 # Optional: skip Docker Hub image build/push:
 gh workflow run release.yml -f tag_name=v2.0.16 -f build_docker=false
 
 # Optional: draft release without Docker build:
-gh workflow run release.yml -f tag_name=v2.0.16 -f draft=true -f build_docker=false
+gh workflow run release.yml -f tag_name=v2.0.16 -f publish_release=false -f build_docker=false
 
 # Interactive mode (prompts for inputs):
 gh workflow run
@@ -84,8 +84,8 @@ gh workflow run
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `tag_name` | string | `v0.0.0` | Version tag to release (e.g., `v2.0.16`). |
-| `draft` | boolean | `false` | When `true`, creates the GitHub Release as a draft. |
-| `build_docker` | boolean | `true` | When `true`, builds and pushes the multi-platform Docker image. |
+| `publish_release` | choice (`true`, `false`) | `true` | When `true`, publishes the release immediately. Set to `false` to create as a draft. |
+| `build_docker` | choice (`true`, `false`) | `true` | When `true`, builds and pushes the multi-platform Docker image. |
 
 Alternatively, pushing a signed git tag matching `v*` will trigger the workflow automatically:
 

--- a/docker/one-time-scripts.sh
+++ b/docker/one-time-scripts.sh
@@ -45,9 +45,5 @@ runuser_wrapper $SCRIPTS/web15rss_fetch.py
 /bin/true # example
 
 # new scripts to prime
-runuser_wrapper /usr/bin/python3 $SCRIPTS/fetch_marine_warnings.py
-runuser_wrapper /usr/bin/python3 $SCRIPTS/fetch_firewx_warnings.py
-runuser_wrapper /usr/bin/python3 $SCRIPTS/fetch_quakes.py
-runuser_wrapper /usr/bin/python3 $SCRIPTS/fetch_fires.py
 
 #############################################


### PR DESCRIPTION
This is based on lessons learned from HamClock project which is a little more complex because it includes android support.

Also squeeze in clearing out the one-time-scripts.sh for the next release.